### PR TITLE
Fix map tile loading errors

### DIFF
--- a/lib/map.dart
+++ b/lib/map.dart
@@ -7,11 +7,13 @@ class map extends StatelessWidget {
     super.key,
     required MapController mapController,
     required LatLng? currentPosition,
+    this.onMapReady,
   }) : _mapController = mapController,
        _currentPosition = currentPosition;
 
   final MapController _mapController;
   final LatLng? _currentPosition;
+  final VoidCallback? onMapReady;
 
   @override
   Widget build(BuildContext context) {
@@ -29,11 +31,12 @@ class map extends StatelessWidget {
         cameraConstraint: CameraConstraint.contain(
           bounds: LatLngBounds(LatLng(-85.0, -180.0), LatLng(85.0, 180.0)),
         ),
+        onMapReady: onMapReady,
       ),
       children: [
         TileLayer(
-          urlTemplate: "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
-          subdomains: ['a', 'b', 'c'],
+          urlTemplate: "https://tile.openstreetmap.org/{z}/{x}/{y}.png",
+          userAgentPackageName: 'com.example.soldier_tracker',
         ),
         MarkerLayer(
           markers: [

--- a/lib/map_screen.dart
+++ b/lib/map_screen.dart
@@ -15,6 +15,7 @@ class MapScreen extends StatefulWidget {
 class _MapScreenState extends State<MapScreen> {
   LatLng? _currentPosition;
   late final MapController _mapController;
+  bool _isMapReady = false;
 
   @override
   void initState() {
@@ -56,16 +57,23 @@ class _MapScreenState extends State<MapScreen> {
     final newPosition = LatLng(lat.toDouble(), lng.toDouble());
     setState(() => _currentPosition = newPosition);
 
-    try {
-      _mapController.move(newPosition, 15);
-    } catch (e) {
-      debugPrint('Error moving map: $e');
+    // Only try to move the map if it's ready and mounted
+    if (_isMapReady && mounted) {
+      try {
+        _mapController.move(newPosition, 15);
+      } catch (e) {
+        debugPrint('Error moving map: $e');
+      }
     }
   }
 
   void _centerMap() {
-    if (_currentPosition != null) {
-      _mapController.move(_currentPosition!, 15);
+    if (_currentPosition != null && _isMapReady && mounted) {
+      try {
+        _mapController.move(_currentPosition!, 15);
+      } catch (e) {
+        debugPrint('Error centering map: $e');
+      }
     }
   }
 
@@ -166,7 +174,15 @@ class _MapScreenState extends State<MapScreen> {
       ),
       body: Stack(
         children: [
-          map(mapController: _mapController, currentPosition: _currentPosition),
+          map(
+            mapController: _mapController, 
+            currentPosition: _currentPosition,
+            onMapReady: () {
+              setState(() {
+                _isMapReady = true;
+              });
+            },
+          ),
           _buildCoordinateOverlay(),
         ],
       ),


### PR DESCRIPTION
Fix OpenStreetMap tile loading and MapController initialization issues.

The application was failing to load OpenStreetMap tiles due to missing User-Agent headers, resulting in 403 errors. Additionally, `MapController` operations were attempted before the map was fully rendered, leading to 'MapController not rendered' exceptions. This PR resolves these by adding the necessary User-Agent and ensuring map operations are only performed after the `onMapReady` callback.

---

[Open in Web](https://www.cursor.com/agents?id=bc-dbf3a02e-e50d-4563-bfc5-e610203bc562) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-dbf3a02e-e50d-4563-bfc5-e610203bc562)